### PR TITLE
Cleanup unused programs, remove unused amdgpu.sg_display=0 for Framework 13

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -39,6 +39,7 @@ in
     ripgrep
     fd
     fzf
+    vscode
   ];
 
   xdg = {

--- a/home-manager/linux/default.nix
+++ b/home-manager/linux/default.nix
@@ -119,7 +119,6 @@ rec {
       # dependency for nwg-displays
       wlr-randr
       framework-tool
-      spotify
       wechat-uos
       brightnessctl
       adbfs-rootless

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -291,6 +291,7 @@ rec {
       "libvirtd"
       "podman"
       "docker"
+      "adbusers"
     ];
   };
 }

--- a/nixos/desktop.nix
+++ b/nixos/desktop.nix
@@ -5,7 +5,7 @@
   ...
 }:
 let
-  delugia-code = pkgs.callPackage /home/zhifan/.config/nixos/delugia-code { };
+  delugia-code = pkgs.callPackage ./delugia-code { };
 in
 rec {
   boot = {

--- a/nixos/framework-13-7040-amd/configuration.nix
+++ b/nixos/framework-13-7040-amd/configuration.nix
@@ -64,6 +64,7 @@
   nixpkgs.config.allowUnfree = true;
 
   programs = {
+    adb.enable = true;
     neovim = {
       enable = true;
       defaultEditor = true;

--- a/nixos/framework-13-7040-amd/hardware-configuration.nix
+++ b/nixos/framework-13-7040-amd/hardware-configuration.nix
@@ -24,7 +24,7 @@
   boot.initrd.kernelModules = [ ];
   boot.kernelModules = [ "kvm-amd" ];
   boot.extraModulePackages = [ ];
-  boot.kernelParams = [ "amdgpu.sg_display=0" ];
+  boot.kernelParams = [ ];
 
   services.power-profiles-daemon.enable = true;
 


### PR DESCRIPTION
This pull request introduces several changes across multiple configuration files, primarily focusing on software package adjustments, user group updates, and hardware configuration refinements. Below is a summary of the most important changes grouped by theme:

### Software package adjustments:
* Added `vscode` to the list of installed packages in `home-manager/home.nix`.
* Removed `spotify` from the list of installed packages in `home-manager/linux/default.nix`.

### User group and permissions updates:
* Added `adbusers` to the list of user groups in `nixos/desktop.nix`.

### Hardware and system configuration:
* Enabled `adb` in the `programs` section of `nixos/framework-13-7040-amd/configuration.nix`.
* Removed the `amdgpu.sg_display=0` kernel parameter from `nixos/framework-13-7040-amd/hardware-configuration.nix`.