### PR TITLE
fix(programs.fzf): enableFishIntegration = false

### DIFF
--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -196,7 +196,8 @@
 
     fzf = {
       enable = true;
-      enableFishIntegration = true;
+      # this overrides some default bindings
+      enableFishIntegration = false;
       tmux.enableShellIntegration = true;
     };
   };


### PR DESCRIPTION
This option overrides the default keybind for Shift-tab which I want to keep